### PR TITLE
Support 'delay' command in initialisation data

### DIFF
--- a/samples/Advanced_Animation/app/application.cpp
+++ b/samples/Advanced_Animation/app/application.cpp
@@ -2,28 +2,10 @@
 #include <Graphics/LcdFont.h>
 #include <Graphics/Renderer.h>
 #include <Services/Profiling/MinMax.h>
-
-#ifdef ENABLE_VIRTUAL_SCREEN
-#include <Graphics/Display/Virtual.h>
-#else
-#include <Graphics/Display/ILI9341.h>
-#endif
+#include <Graphics/SampleConfig.h>
 
 namespace
 {
-#ifdef ENABLE_VIRTUAL_SCREEN
-Graphics::Display::Virtual tft;
-#else
-HSPI::Controller spi;
-Graphics::Display::ILI9341 tft(spi);
-constexpr HSPI::PinSet TFT_PINSET{HSPI::PinSet::overlap};
-constexpr uint8_t TFT_CS{2};
-constexpr uint8_t TFT_RESET_PIN{4};
-constexpr uint8_t TFT_DC_PIN{5};
-// Not used in this sample, but needs to be kept high
-constexpr uint8_t TOUCH_CS_PIN{15};
-#endif
-
 // Demonstrate other stuff can be done whilst rendering proceeds
 SimpleTimer backgroundTimer;
 CpuCycleTimer interval;
@@ -227,16 +209,7 @@ void renderFrame()
 void setup()
 {
 	Serial.println("Display start");
-#ifdef ENABLE_VIRTUAL_SCREEN
-	tft.begin();
-#else
-	// Touch CS
-	pinMode(TOUCH_CS_PIN, OUTPUT);
-	digitalWrite(TOUCH_CS_PIN, HIGH);
-
-	spi.begin();
-	tft.begin(TFT_PINSET, TFT_CS, TFT_DC_PIN, TFT_RESET_PIN, 40000000);
-#endif
+	initDisplay();
 
 	tft.setOrientation(Orientation::deg270);
 	tftSize = tft.getSize();

--- a/samples/Basic_Animation/app/application.cpp
+++ b/samples/Basic_Animation/app/application.cpp
@@ -1,28 +1,10 @@
 #include <SmingCore.h>
 #include <Graphics.h>
 #include <Services/Profiling/MinMax.h>
-
-#ifdef ENABLE_VIRTUAL_SCREEN
-#include <Graphics/Display/Virtual.h>
-#else
-#include <Graphics/Display/ILI9341.h>
-#endif
+#include <Graphics/SampleConfig.h>
 
 namespace
 {
-#ifdef ENABLE_VIRTUAL_SCREEN
-Graphics::Display::Virtual tft;
-#else
-HSPI::Controller spi;
-Graphics::Display::ILI9341 tft(spi);
-constexpr HSPI::PinSet TFT_PINSET{HSPI::PinSet::overlap};
-constexpr uint8_t TFT_CS{2};
-constexpr uint8_t TFT_RESET_PIN{4};
-constexpr uint8_t TFT_DC_PIN{5};
-// Not used in this sample, but needs to be kept high
-constexpr uint8_t TOUCH_CS_PIN{15};
-#endif
-
 using namespace Graphics;
 
 struct Frame {
@@ -182,17 +164,7 @@ void renderFrame()
 void setup()
 {
 	Serial.println("Display start");
-	bool initOk;
-#ifdef ENABLE_VIRTUAL_SCREEN
-	initOk = tft.begin();
-#else
-	// Touch CS
-	pinMode(TOUCH_CS_PIN, OUTPUT);
-	digitalWrite(TOUCH_CS_PIN, HIGH);
-
-	spi.begin();
-	initOk = tft.begin(TFT_PINSET, TFT_CS, TFT_DC_PIN, TFT_RESET_PIN, 40000000);
-#endif
+	bool initOk = initDisplay();
 
 	if(!initOk) {
 		Serial.println(F("TFT initialisation failed"));

--- a/samples/Basic_Graphics/app/application.cpp
+++ b/samples/Basic_Graphics/app/application.cpp
@@ -7,6 +7,7 @@
 #include <RapidXML.h>
 #include <Storage/PartitionStream.h>
 #include <resource.h>
+#include <Graphics/SampleConfig.h>
 
 #ifdef ENABLE_MALLOC_COUNT
 #include <malloc_count.h>
@@ -16,31 +17,10 @@
 #include <Storage/FileDevice.h>
 #endif
 
-#ifdef ENABLE_VIRTUAL_SCREEN
-#include <Graphics/Display/Virtual.h>
-#else
-#include <Graphics/Display/ILI9341.h>
-#endif
-
 using namespace Graphics;
 
 namespace
 {
-#ifdef ENABLE_VIRTUAL_SCREEN
-Display::Virtual tft;
-#else
-HSPI::Controller spi;
-Display::ILI9341 tft(spi);
-
-// Pin setup
-constexpr HSPI::PinSet TFT_PINSET{HSPI::PinSet::overlap};
-constexpr uint8_t TFT_CS{2};
-constexpr uint8_t TFT_RESET_PIN{4};
-constexpr uint8_t TFT_DC_PIN{5};
-// Not used in this sample, but needs to be kept high
-constexpr uint8_t TOUCH_CS_PIN{15};
-#endif
-
 constexpr Orientation portrait{Orientation::deg180};
 constexpr Orientation landscape{Orientation::deg270};
 
@@ -1746,24 +1726,9 @@ void init()
 	targetSymbol.drawRect(Pen(Color::Gray, 3), r);
 
 	Serial.println("Display start");
-#ifdef ENABLE_VIRTUAL_SCREEN
-	tft.begin();
-	// tft.setMode(Display::Virtual::Mode::Debug);
-#else
+	initDisplay();
 
-	// Touch CS
-	pinMode(TOUCH_CS_PIN, OUTPUT);
-	digitalWrite(TOUCH_CS_PIN, HIGH);
-
-	spi.begin();
-
-	/*
-	 * ILI9341 min. clock cycle is 100ns write, 150ns read.
-	 * In practice, writes work at 40MHz, reads at 27MHz.
-	 * Attempting to read at 40MHz results in colour corruption.
-	 */
-	tft.begin(TFT_PINSET, TFT_CS, TFT_DC_PIN, TFT_RESET_PIN, 27000000);
-
+#ifndef ENABLE_VIRTUAL_SCREEN
 	Serial.printf(_F("Speed: %u\r\n"), tft.getSpeed());
 	Serial.printf(_F("DisplayID: 0x%06x\r\n"), tft.readDisplayId());
 	Serial.printf(_F("Status: 0x%08x\r\n"), tft.readDisplayStatus());

--- a/samples/Basic_Graphics/tft-ili9341.hw
+++ b/samples/Basic_Graphics/tft-ili9341.hw
@@ -5,7 +5,7 @@
     "partitions": {
         "resource": {
             "device": "spiFlash",
-            "address": "0x00100000",
+            "address": "0x00280000",
             "size": "1M",
             "type": "user",
             "subtype": 1,

--- a/samples/Basic_Touch/app/application.cpp
+++ b/samples/Basic_Touch/app/application.cpp
@@ -4,22 +4,16 @@
 #include <Graphics/Touch/XPT2046.h>
 #include <Graphics/RenderQueue.h>
 #include <Graphics/TextBuilder.h>
+#include <Graphics/SampleConfig.h>
 
 namespace
 {
-HSPI::Controller spi;
-Graphics::Display::ILI9341 tft(spi);
 Graphics::XPT2046 touch(spi, tft);
 Graphics::RenderQueue renderQueue(tft);
 
 using namespace Graphics;
 
 // Pin setup
-constexpr HSPI::PinSet TFT_PINSET{HSPI::PinSet::overlap};
-constexpr uint8_t TFT_CS{2};
-constexpr uint8_t TFT_RESET_PIN{4};
-constexpr uint8_t TFT_DC_PIN{5};
-
 constexpr HSPI::PinSet TOUCH_PINSET{HSPI::PinSet::overlap};
 constexpr uint8_t TOUCH_CS{0};
 constexpr uint8_t TOUCH_IRQ_PIN{2};
@@ -267,8 +261,8 @@ void init()
 #endif
 
 	Serial.println("Display start");
-	spi.begin();
-	tft.begin(TFT_PINSET, TFT_CS, TFT_DC_PIN, TFT_RESET_PIN, 40000000);
+	initDisplay();
+
 	touch.begin(TOUCH_PINSET, TOUCH_CS, TOUCH_IRQ_PIN);
 	touch.setOrientation(Orientation::deg270);
 	touch.setCallback(touchChanged);

--- a/samples/Bresenham/app/application.cpp
+++ b/samples/Bresenham/app/application.cpp
@@ -1,32 +1,12 @@
 #include <SmingCore.h>
 #include <Graphics.h>
 #include "bresenham.h"
-
-#ifdef ENABLE_VIRTUAL_SCREEN
-#include <Graphics/Display/Virtual.h>
-#else
-#include <Graphics/Display/ILI9341.h>
-#endif
+#include <Graphics/SampleConfig.h>
 
 using namespace Graphics;
 
 namespace
 {
-#ifdef ENABLE_VIRTUAL_SCREEN
-Display::Virtual tft;
-#else
-HSPI::Controller spi;
-Display::ILI9341 tft(spi);
-
-// Pin setup
-constexpr HSPI::PinSet TFT_PINSET{HSPI::PinSet::overlap};
-constexpr uint8_t TFT_CS{2};
-constexpr uint8_t TFT_RESET_PIN{4};
-constexpr uint8_t TFT_DC_PIN{5};
-// Not used in this sample, but needs to be kept high
-constexpr uint8_t TOUCH_CS_PIN{15};
-#endif
-
 constexpr Orientation portrait{Orientation::deg180};
 constexpr Orientation landscape{Orientation::deg270};
 
@@ -184,24 +164,7 @@ void init()
 	spiffs_mount();
 
 	Serial.println("Display start");
-#ifdef ENABLE_VIRTUAL_SCREEN
-	tft.begin();
-	// tft.setMode(Display::Virtual::Mode::Debug);
-#else
-
-	// Touch CS
-	pinMode(TOUCH_CS_PIN, OUTPUT);
-	digitalWrite(TOUCH_CS_PIN, HIGH);
-
-	spi.begin();
-
-	/*
-	 * ILI9341 min. clock cycle is 100ns write, 150ns read.
-	 * In practice, writes work at 40MHz, reads at 27MHz.
-	 * Attempting to read at 40MHz results in colour corruption.
-	 */
-	tft.begin(TFT_PINSET, TFT_CS, TFT_DC_PIN, TFT_RESET_PIN, 27000000);
-#endif
+	initDisplay();
 
 	tftPixelFormat = tft.getPixelFormat();
 

--- a/samples/Custom_Object/app/application.cpp
+++ b/samples/Custom_Object/app/application.cpp
@@ -1,33 +1,13 @@
 #include <SmingCore.h>
 #include <Graphics.h>
 #include <Graphics/Debug.h>
-
-#ifdef ENABLE_VIRTUAL_SCREEN
-#include <Graphics/Display/Virtual.h>
-#else
-#include <Graphics/Display/ILI9341.h>
-#endif
+#include <Graphics/SampleConfig.h>
 
 using Color = Graphics::Color;
 using FontStyle = Graphics::FontStyle;
 
 namespace
 {
-#ifdef ENABLE_VIRTUAL_SCREEN
-Graphics::Display::Virtual tft;
-#else
-HSPI::Controller spi;
-Graphics::Display::ILI9341 tft(spi);
-
-// Pin setup
-constexpr HSPI::PinSet TFT_PINSET{HSPI::PinSet::overlap};
-constexpr uint8_t TFT_CS{2};
-constexpr uint8_t TFT_RESET_PIN{4};
-constexpr uint8_t TFT_DC_PIN{5};
-// Not used in this sample, but needs to be kept high
-constexpr uint8_t TOUCH_CS_PIN{15};
-#endif
-
 Graphics::RenderQueue renderQueue(tft);
 
 // Demonstrate other stuff can be done whilst rendering proceeds
@@ -221,17 +201,7 @@ void init()
 #endif
 
 	Serial.println("Display start");
-#ifdef ENABLE_VIRTUAL_SCREEN
-	tft.begin();
-#else
-
-	// Touch CS
-	pinMode(TOUCH_CS_PIN, OUTPUT);
-	digitalWrite(TOUCH_CS_PIN, HIGH);
-
-	spi.begin();
-	tft.begin(TFT_PINSET, TFT_CS, TFT_DC_PIN, TFT_RESET_PIN, 40000000);
-#endif
+	initDisplay();
 
 	backgroundTimer.initializeMs<500>([]() {
 		debug_i("Background timer %u, free heap %u", interval.elapsedTicks(), system_get_free_heap_size());

--- a/src/Display/ILI9341.cpp
+++ b/src/Display/ILI9341.cpp
@@ -399,10 +399,9 @@ private:
 
 bool ILI9341::begin(HSPI::PinSet pinSet, uint8_t chipSelect, uint8_t dcPin, uint8_t resetPin, uint32_t clockSpeed)
 {
-	if(!HSPI::Device::begin(pinSet, chipSelect)) {
+	if(!HSPI::Device::begin(pinSet, chipSelect, clockSpeed)) {
 		return false;
 	}
-	setSpeed(clockSpeed);
 	setBitOrder(MSBFIRST);
 	setClockMode(HSPI::ClockMode::mode0);
 	setIoMode(HSPI::IoMode::SPI);

--- a/src/DisplayList.cpp
+++ b/src/DisplayList.cpp
@@ -293,6 +293,9 @@ bool DisplayList::readEntry(Entry& entry)
 	case Code::read:
 		read(&entry.data, sizeof(entry.data));
 		return true;
+	case Code::delay:
+		entry.value = buffer[offset++];
+		break;
 	default:
 		return false;
 	}

--- a/src/SpiDisplay.cpp
+++ b/src/SpiDisplay.cpp
@@ -1,0 +1,80 @@
+/**
+ * ILI9341.cpp
+ *
+ * Copyright 2021 mikee47 <mike@sillyhouse.net>
+ *
+ * This file is part of the Sming-Graphics Library
+ *
+ * This library is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, version 3 or later.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this library.
+ * If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @author: May 2021 - mikee47 <mike@sillyhouse.net>
+ *
+ * This code contains some reworked code from the Adafruit_ILI9341 display driver.
+ * 
+ * See https://github.com/adafruit/Adafruit_ILI9341
+ *
+ ****/
+
+#include "include/Graphics/SpiDisplay.h"
+
+namespace Graphics
+{
+bool SpiDisplay::begin(HSPI::PinSet pinSet, uint8_t chipSelect, uint8_t resetPin, uint32_t clockSpeed)
+{
+	if(!HSPI::Device::begin(pinSet, chipSelect, clockSpeed)) {
+		return false;
+	}
+	setBitOrder(MSBFIRST);
+	setClockMode(HSPI::ClockMode::mode0);
+	setIoMode(HSPI::IoMode::SPI);
+
+	this->resetPin = resetPin;
+	if(resetPin != PIN_NONE) {
+		pinMode(resetPin, OUTPUT);
+		reset(false);
+		reset(true);
+		os_delay_us(10000);
+		reset(false);
+		os_delay_us(1000);
+	}
+
+	return true;
+}
+
+void SpiDisplay::execute(const SpiDisplayList::Commands& commands, const FSTR::ObjectBase& data)
+{
+	SpiDisplayList src(commands, addrWindow, data);
+
+	uint32_t start{0};
+	uint32_t current{0};
+
+	auto sendList = [&]() {
+		auto len = current - start;
+		if(len != 0) {
+			SpiDisplayList list(commands, addrWindow, src.getContent() + start, len);
+			execute(list);
+		}
+		current = start = src.readOffset();
+	};
+
+	DisplayList::Entry entry;
+	while(src.readEntry(entry)) {
+		if(entry.code == DisplayList::Code::delay) {
+			sendList();
+			os_delay_us(entry.value * 1000);
+			continue;
+		}
+		current = src.readOffset();
+	}
+	sendList();
+}
+
+} // namespace Graphics

--- a/src/SpiDisplayList.cpp
+++ b/src/SpiDisplayList.cpp
@@ -172,6 +172,10 @@ bool IRAM_ATTR SpiDisplayList::fillRequest()
 		code = Code::none;
 		dbgint("read %u", datalen);
 		break;
+	case Code::delay:
+		// Ignore
+		++offset;
+		return fillRequest();
 	default:
 		return false;
 	}

--- a/src/Touch/XPT2046.cpp
+++ b/src/Touch/XPT2046.cpp
@@ -78,11 +78,10 @@ int16_t bestTwoAverage(int16_t a, int16_t b, int16_t c)
 
 bool XPT2046::begin(HSPI::PinSet pinSet, uint8_t chipSelect, uint8_t irqPin)
 {
-	if(!HSPI::Device::begin(pinSet, chipSelect)) {
+	if(!HSPI::Device::begin(pinSet, chipSelect, clockSpeed)) {
 		return false;
 	}
 
-	setSpeed(clockSpeed);
 	setBitOrder(MSBFIRST);
 	setClockMode(HSPI::ClockMode::mode0);
 	setIoMode(HSPI::IoMode::SPI);

--- a/src/include/Graphics/Display/ILI9341.h
+++ b/src/include/Graphics/Display/ILI9341.h
@@ -98,6 +98,8 @@ private:
 		execute(list.request);
 	}
 
+	void execute(const SpiDisplayList::Commands& commands, const FSTR::ObjectBase& data);
+
 	static bool transferBeginEnd(HSPI::Request& request);
 
 	void reset(bool state)

--- a/src/include/Graphics/Display/ILI9341.h
+++ b/src/include/Graphics/Display/ILI9341.h
@@ -115,13 +115,9 @@ private:
 		return HSPI::IoMode::SPI;
 	}
 
-	static bool staticRequestCallback(HSPI::Request& request);
-
 	uint8_t dcPin{PIN_NONE};
 	bool dcState{};
 	uint8_t resetPin{PIN_NONE};
-	uint8_t listIndex{0}; ///< Next display list to write to
-	void* param{nullptr};
 	AddressWindow addrWindow{};
 };
 

--- a/src/include/Graphics/Display/ILI9341.h
+++ b/src/include/Graphics/Display/ILI9341.h
@@ -21,10 +21,7 @@
 
 #pragma once
 
-#include "../Device.h"
-#include <HSPI/Device.h>
-#include "../SpiDisplayList.h"
-#include <Digital.h>
+#include "../SpiDisplay.h"
 
 namespace Graphics
 {
@@ -32,19 +29,15 @@ namespace Display
 {
 class ILI9341Surface;
 
-class ILI9341 : private HSPI::Device, public Device, public RenderTarget
+class ILI9341 : public SpiDisplay
 {
 public:
 	static constexpr Size nativeSize{240, 320};
 
-	ILI9341(HSPI::Controller& spi) : HSPI::Device(spi)
-	{
-	}
+	using SpiDisplay::SpiDisplay;
 
 	bool begin(HSPI::PinSet pinSet, uint8_t chipSelect, uint8_t dcPin, uint8_t resetPin = PIN_NONE,
 			   uint32_t clockSpeed = 4000000);
-
-	using HSPI::Device::getSpeed;
 
 	uint32_t readRegister(uint8_t cmd, uint8_t byteCount);
 
@@ -89,36 +82,10 @@ public:
 private:
 	friend class ILI9341Surface;
 
-	using HSPI::Device::execute;
-
-	void execute(SpiDisplayList& list, DisplayList::Callback callback = nullptr, void* param = nullptr)
-	{
-		list.prepare(callback, param);
-		list.fillRequest();
-		execute(list.request);
-	}
-
-	void execute(const SpiDisplayList::Commands& commands, const FSTR::ObjectBase& data);
-
 	static bool transferBeginEnd(HSPI::Request& request);
-
-	void reset(bool state)
-	{
-		if(resetPin == PIN_NONE) {
-			return;
-		}
-		digitalWrite(resetPin, !state);
-	}
-
-	HSPI::IoModes getSupportedIoModes() const override
-	{
-		return HSPI::IoMode::SPI;
-	}
 
 	uint8_t dcPin{PIN_NONE};
 	bool dcState{};
-	uint8_t resetPin{PIN_NONE};
-	AddressWindow addrWindow{};
 };
 
 } // namespace Display

--- a/src/include/Graphics/DisplayList.h
+++ b/src/include/Graphics/DisplayList.h
@@ -31,6 +31,7 @@
 #define DEFINE_RB_COMMAND(cmd, len, ...) uint8_t(uint8_t(DisplayList::Code::command) | (len << 4)), cmd, ##__VA_ARGS__,
 #define DEFINE_RB_COMMAND_LONG(cmd, len, ...)                                                                          \
 	uint8_t(uint8_t(DisplayList::Code::command) | 0xf0), len, cmd, ##__VA_ARGS__,
+#define DEFINE_RB_DELAY(ms) uint8_t(DisplayList::Code::delay), ms,
 #define DEFINE_RB_ARRAY(name, ...) DEFINE_FSTR_ARRAY_LOCAL(name, uint8_t, ##__VA_ARGS__)
 
 namespace Graphics
@@ -53,7 +54,8 @@ namespace Graphics
 	XX(writeDataBuffer, 1 + 2 + sizeof(void*), "Write data: cmd, len, dataptr")                                        \
 	XX(readStart, 2 + sizeof(void*), "Read data: len, bufptr (first packet after setting address)")                    \
 	XX(read, 2 + sizeof(void*), "Read data: len, bufptr (Second and subsequent packets)")                              \
-	XX(callback, 2 + sizeof(void*) + 3, "Callback: paramlen, callback, ALIGN4, params")
+	XX(callback, 2 + sizeof(void*) + 3, "Callback: paramlen, callback, ALIGN4, params")                                \
+	XX(delay, 1, "Wait n milliseconds before continuing")
 
 /**
  * @brief Supports DisplayList blend operations
@@ -226,7 +228,7 @@ public:
 	}
 
 	/**
-	 * @brief Create pre-defined display list
+	 * @brief Create pre-defined display list from flash data
 	 *
 	 * Used for initialisation data
 	 */
@@ -234,6 +236,17 @@ public:
 	{
 		data.read(0, buffer.get(), data.size());
 		size = data.length();
+	}
+
+	/**
+	 * @brief Create initialised display list from RAM data
+	 *
+	 * Used for initialisation data
+	 */
+	DisplayList(AddressWindow& addrWindow, const void* data, size_t length) : DisplayList(addrWindow, length)
+	{
+		memcpy(buffer.get(), data, length);
+		size = length;
 	}
 
 	/**

--- a/src/include/Graphics/SampleConfig.h
+++ b/src/include/Graphics/SampleConfig.h
@@ -1,0 +1,80 @@
+/**
+ * SampleConfig.h
+ *
+ * Common definitions for sample applications
+ *
+ ****/
+
+#pragma once
+
+#ifdef ENABLE_VIRTUAL_SCREEN
+#include <Graphics/Display/Virtual.h>
+#else
+#include <Graphics/Display/ILI9341.h>
+#endif
+
+namespace
+{
+#ifdef ENABLE_VIRTUAL_SCREEN
+Graphics::Display::Virtual tft;
+#else
+HSPI::Controller spi;
+Graphics::Display::ILI9341 tft(spi);
+
+#ifdef ARCH_ESP32
+constexpr HSPI::SpiBus spiBus{HSPI::SpiBus::DEFAULT};
+constexpr HSPI::PinSet TFT_PINSET{HSPI::PinSet::normal};
+#ifdef CONFIG_IDF_TARGET_ESP32
+constexpr uint8_t TFT_CS{2};
+constexpr uint8_t TFT_RESET_PIN{4};
+constexpr uint8_t TFT_DC_PIN{5};
+constexpr uint8_t TOUCH_CS_PIN{15};
+#elif defined CONFIG_IDF_TARGET_ESP32S2
+constexpr uint8_t TFT_CS{2};
+constexpr uint8_t TFT_RESET_PIN{4};
+constexpr uint8_t TFT_DC_PIN{5};
+constexpr uint8_t TOUCH_CS_PIN{15};
+#elif defined CONFIG_IDF_TARGET_ESP32C3
+constexpr uint8_t TFT_CS{2};
+constexpr uint8_t TFT_RESET_PIN{4};
+constexpr uint8_t TFT_DC_PIN{5};
+constexpr uint8_t TOUCH_CS_PIN{15};
+#endif
+#else
+// Pin setup
+constexpr HSPI::PinSet TFT_PINSET{HSPI::PinSet::overlap};
+constexpr uint8_t TFT_CS{2};
+constexpr uint8_t TFT_RESET_PIN{4};
+constexpr uint8_t TFT_DC_PIN{5};
+// Not used in this sample, but needs to be kept high
+constexpr uint8_t TOUCH_CS_PIN{15};
+#endif
+#endif
+
+bool initDisplay()
+{
+#ifdef ENABLE_VIRTUAL_SCREEN
+	if(!tft.begin()) {
+		return false;
+	}
+	// tft.setMode(Display::Virtual::Mode::Debug);
+	return true;
+#else
+	// Touch CS
+	pinMode(TOUCH_CS_PIN, OUTPUT);
+	digitalWrite(TOUCH_CS_PIN, HIGH);
+
+	if(!spi.begin()) {
+		return false;
+	}
+
+	/*
+	 * ILI9341 min. clock cycle is 100ns write, 150ns read.
+	 * In practice, writes work at 40MHz, reads at 27MHz.
+	 * Attempting to read at 40MHz results in colour corruption.
+	 */
+	return tft.begin(TFT_PINSET, TFT_CS, TFT_DC_PIN, TFT_RESET_PIN, 27000000);
+#endif
+}
+
+} // namespace

--- a/src/include/Graphics/SpiDisplay.h
+++ b/src/include/Graphics/SpiDisplay.h
@@ -1,0 +1,70 @@
+/**
+ * SpiDisplay.h
+ *
+ * Copyright 2021 mikee47 <mike@sillyhouse.net>
+ *
+ * This file is part of the Sming-Graphics Library
+ *
+ * This library is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, version 3 or later.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this library.
+ * If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @author: May 2021 - mikee47 <mike@sillyhouse.net>
+ *
+ ****/
+
+#pragma once
+
+#include "Device.h"
+#include <HSPI/Device.h>
+#include "SpiDisplayList.h"
+#include <Digital.h>
+
+namespace Graphics
+{
+class SpiDisplay : protected HSPI::Device, public Device, public RenderTarget
+{
+public:
+	SpiDisplay(HSPI::Controller& spi) : HSPI::Device(spi)
+	{
+	}
+
+	bool begin(HSPI::PinSet pinSet, uint8_t chipSelect, uint8_t resetPin = PIN_NONE, uint32_t clockSpeed = 4000000);
+
+	using HSPI::Device::getSpeed;
+
+protected:
+	using HSPI::Device::execute;
+
+	void execute(SpiDisplayList& list, DisplayList::Callback callback = nullptr, void* param = nullptr)
+	{
+		list.prepare(callback, param);
+		list.fillRequest();
+		execute(list.request);
+	}
+
+	void execute(const SpiDisplayList::Commands& commands, const FSTR::ObjectBase& data);
+
+	void reset(bool state)
+	{
+		if(resetPin != PIN_NONE) {
+			digitalWrite(resetPin, !state);
+		}
+	}
+
+	HSPI::IoModes getSupportedIoModes() const override
+	{
+		return HSPI::IoMode::SPI;
+	}
+
+	uint8_t resetPin{PIN_NONE};
+	AddressWindow addrWindow{};
+};
+
+} // namespace Graphics

--- a/src/include/Graphics/SpiDisplayList.h
+++ b/src/include/Graphics/SpiDisplayList.h
@@ -48,13 +48,8 @@ public:
 		uint8_t writeStart;
 	};
 
-	SpiDisplayList(const Commands& commands, AddressWindow& addrWindow, size_t bufferSize)
-		: DisplayList(addrWindow, bufferSize), commands(commands)
-	{
-	}
-
-	SpiDisplayList(const Commands& commands, AddressWindow& addrWindow, const FSTR::ObjectBase& data)
-		: DisplayList(addrWindow, data), commands(commands)
+	template<typename... Params> SpiDisplayList(const Commands& commands, Params&&... params)
+		: DisplayList(params...), commands(commands)
 	{
 	}
 


### PR DESCRIPTION
This PR provides a base `SpiDisplay` class and new `initialise` method. This adds support for delays in static displaylists.

See #1 for discussion.