### PR TITLE
Add hardware scrolling support

### DIFF
--- a/src/Arch/Host/Virtual.cpp
+++ b/src/Arch/Host/Virtual.cpp
@@ -560,6 +560,32 @@ bool Virtual::setOrientation(Orientation orientation)
 	return sizeChanged();
 }
 
+bool Virtual::setScrollMargins(uint16_t top, uint16_t bottom)
+{
+	if(top + bottom >= nativeSize.h) {
+		debug_e("[VS] setScrollMargins(%u, %u) invalid parameters", top, bottom);
+		return false;
+	}
+
+	scrollMargins.top = top;
+	scrollMargins.bottom = bottom;
+
+	debug_d("[VS] setScrollMargins(%u, %u)", top, bottom);
+	return true;
+}
+
+bool Virtual::scroll(int16_t y)
+{
+	CommandList list(addrWindow, 32);
+	Rect area(0, scrollMargins.top, nativeSize.w, nativeSize.h - scrollMargins.top - scrollMargins.bottom);
+	Point shift(0, -y);
+	debug_d("[VS] Scroll(%s, %s)", area.toString().c_str(), shift.toString().c_str());
+	list.writeCommand(Command::Scroll{area, shift, false, true});
+	list.prepare();
+	thread->transfer(list);
+	return true;
+}
+
 Surface* Virtual::createSurface(size_t bufferSize)
 {
 	return new VirtualSurface(*this, bufferSize ?: 512U);

--- a/src/Console.cpp
+++ b/src/Console.cpp
@@ -1,0 +1,187 @@
+/****
+ * Console.cpp
+ *
+ * Copyright 2021 mikee47 <mike@sillyhouse.net>
+ *
+ * This file is part of the Sming-Graphics Library
+ *
+ * This library is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, version 3 or later.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this library.
+ * If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @author: October 2021 - mikee47 <mike@sillyhouse.net>
+ *
+ ****/
+
+#include "include/Graphics/Console.h"
+#include "include/Graphics/LcdFont.h"
+
+namespace Graphics
+{
+size_t Console::write(const uint8_t* data, size_t size)
+{
+	auto str = reinterpret_cast<const char*>(data);
+	if(paused) {
+		pauseBuffer.concat(str, size);
+	} else {
+		buffer.concat(str, size);
+	}
+	update();
+	return size;
+}
+
+void Console::pause(bool state)
+{
+	paused = state;
+	if(paused) {
+		return;
+	}
+	if(pauseBuffer) {
+		if(buffer.length() == 0) {
+			buffer = std::move(pauseBuffer);
+		} else {
+			buffer.concat(pauseBuffer);
+		}
+		pauseBuffer = nullptr;
+	}
+	update();
+}
+
+void Console::update()
+{
+	if(scene) {
+		// Busy: Will be called again when current scene has completed
+		return;
+	}
+
+	if(buffer.length() == 0) {
+		return;
+	}
+
+	scene.reset(new SceneObject(display));
+	Scale scale{1, 2};
+	constexpr FontStyles style{};
+	auto face = lcdFont.getFace(style);
+	auto lineHeight = scale.scaleY(face->height());
+	auto text = new TextObject(display.getSize());
+	constexpr Color fore(Color::White);
+	constexpr Color back(Color::Black);
+
+	Point pt = cursor;
+	auto len = buffer.length();
+	auto buf = buffer.begin();
+	unsigned start = 0;
+	unsigned offset = start;
+
+	// Clear unused space at end of line
+	auto clreol = [&](Point pos) {
+		Rect r(pos, text->bounds.w - pos.x, lineHeight);
+		if(r.w != 0) {
+			scene->fillRect(back, r);
+		}
+	};
+
+	// Add a run of text
+	auto addLine = [&]() {
+		if(offset > start) {
+			text->addRun(cursor, pt.x - cursor.x, start, offset - start);
+			start = offset;
+		}
+		cursor = pt;
+	};
+
+	// Parse text buffer and emit RUN elements
+	for(unsigned i = 0; i < len; ++i) {
+		auto c = buf[i];
+		if(c == '\n') {
+			addLine();
+			cursor.y += lineHeight;
+			pt = cursor;
+			continue;
+		}
+		if(c == '\r') {
+			addLine();
+			cursor.x = pt.x = 0;
+			continue;
+		}
+		if(c == '\t') {
+			c = ' ';
+		} else if(c < ' ') {
+			continue;
+		}
+		buf[offset++] = c;
+		auto metrics = face->getMetrics(c);
+		auto adv = scale.scaleX(metrics.advance);
+		if(pt.x + adv > text->bounds.w) {
+			addLine();
+			cursor.x = 0;
+			cursor.y += lineHeight;
+			pt = cursor;
+		}
+		pt.x += adv;
+	}
+	if(pt.x > cursor.x) {
+		++offset;
+		addLine();
+	}
+
+	// If cursor has extended below bottom of screen then scroll display
+	int overflow = cursor.y + lineHeight - text->bounds.h;
+	if(overflow > 0) {
+		cursor.y -= overflow;
+		// scroll display up
+		display.scroll(overflow);
+
+		// Adjust element positions
+		for(auto& el : text->elements) {
+			auto seg = reinterpret_cast<TextObject::RunElement*>(&el);
+			seg->pos.y -= overflow;
+		}
+
+		// Remove any elements which have scrolled off top of screen
+		TextObject::RunElement* seg;
+		while((seg = reinterpret_cast<TextObject::RunElement*>(text->elements.head()))) {
+			if(seg->pos.y >= 0) {
+				break;
+			}
+			text->elements.remove(seg);
+		}
+
+		// Ensure final line is properly erased
+		clreol(cursor);
+	}
+
+	// Move buffer into an asset and add to scene
+	auto textAsset = new TextAsset(std::move(buffer));
+	scene->addAsset(textAsset);
+	// Insert config. elements ahead of runs
+	text->elements.insert(new TextObject::FontElement(*face, scale, style));
+	text->elements.insert(new TextObject::ColorElement(fore, back));
+	text->elements.insert(new TextObject::TextElement(*textAsset));
+
+	scene->addObject(text);
+
+	renderQueue.render(scene.get(), [this](SceneObject*) {
+		scene.reset();
+		update();
+	});
+}
+
+void Console::systemDebugOutput(bool enable)
+{
+	if(enable) {
+		m_setPuts([this](const char* str, size_t len) -> size_t {
+			return write(reinterpret_cast<const uint8_t*>(str), len);
+		});
+	} else {
+		m_setPuts(nullptr);
+	}
+}
+
+} // namespace Graphics

--- a/src/MipiDisplay.cpp
+++ b/src/MipiDisplay.cpp
@@ -162,6 +162,37 @@ bool IRAM_ATTR MipiDisplay::transferBeginEnd(HSPI::Request& request)
 	return true;
 }
 
+bool MipiDisplay::setScrollMargins(uint16_t top, uint16_t bottom)
+{
+	// TFA + VSA + BFA == 320
+	if(top + bottom > resolution.h) {
+		return false;
+	}
+	uint16_t data[]{
+		swapBytes(top),
+		swapBytes(resolution.h - (top + bottom)),
+		swapBytes(bottom),
+	};
+	SpiDisplayList list(commands, addrWindow, 16);
+	list.writeCommand(Mipi::DCS_SET_SCROLL_AREA, data, sizeof(data));
+	execute(list);
+	return true;
+}
+
+bool MipiDisplay::scroll(int16_t y)
+{
+	y = scrollOffset - y;
+	while(y < 0) {
+		y += resolution.h;
+	}
+	y %= resolution.h;
+	SpiDisplayList list(commands, addrWindow, 16);
+	list.writeCommand(Mipi::DCS_SET_SCROLL_START, swapBytes(y), 2);
+	execute(list);
+	scrollOffset = y;
+	return true;
+}
+
 /*
  * MipiSurface
  */

--- a/src/SpiDisplayList.cpp
+++ b/src/SpiDisplayList.cpp
@@ -33,16 +33,6 @@
 
 namespace Graphics
 {
-__forceinline uint16_t swapBytes(uint16_t w)
-{
-	return (w >> 8) | (w << 8);
-}
-
-__forceinline uint32_t makeWord(uint16_t w1, uint16_t w2)
-{
-	return uint32_t(swapBytes(w1)) | (swapBytes(w2) << 16);
-}
-
 bool IRAM_ATTR SpiDisplayList::fillRequest()
 {
 	request.cmdLen = 0;

--- a/src/Touch/XPT2046.cpp
+++ b/src/Touch/XPT2046.cpp
@@ -91,9 +91,9 @@ bool XPT2046::begin(HSPI::PinSet pinSet, uint8_t chipSelect, uint8_t irqPin)
 
 	this->irqPin = irqPin;
 	if(irqPin != PIN_NONE) {
+		isrTouch = this;
 		pinMode(irqPin, INPUT);
 		attachInterrupt(irqPin, isr, FALLING);
-		isrTouch = this;
 	}
 
 	return true;

--- a/src/include/Arch/Host/Graphics/Display/Virtual.h
+++ b/src/include/Arch/Host/Graphics/Display/Virtual.h
@@ -86,6 +86,9 @@ public:
 		return PixelFormat::BGR24;
 	}
 
+	bool setScrollMargins(uint16_t top, uint16_t bottom) override;
+	bool scroll(int16_t y) override;
+
 	Surface* createSurface(size_t bufferSize = 0) override;
 
 private:
@@ -93,11 +96,17 @@ private:
 	friend NetworkThread;
 	friend VirtualSurface;
 
+	struct ScrollMargins {
+		uint16_t top;
+		uint16_t bottom;
+	};
+
 	bool sizeChanged();
 
 	std::unique_ptr<NetworkThread> thread;
 	Size nativeSize{};
 	AddressWindow addrWindow{};
+	ScrollMargins scrollMargins;
 	Mode mode;
 };
 

--- a/src/include/Graphics/Console.h
+++ b/src/include/Graphics/Console.h
@@ -1,0 +1,85 @@
+/****
+ * Console.h
+ *
+ * Copyright 2021 mikee47 <mike@sillyhouse.net>
+ *
+ * This file is part of the Sming-Graphics Library
+ *
+ * This library is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, version 3 or later.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this library.
+ * If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @author: October 2021 - mikee47 <mike@sillyhouse.net>
+ *
+ ****/
+
+#pragma once
+
+#include "AbstractDisplay.h"
+#include "RenderQueue.h"
+#include <memory>
+
+namespace Graphics
+{
+class Console : public Print
+{
+public:
+	/**
+	 * @brief Console constructor
+	 * @param display Output device
+	 * @param renderQueue Allows shared access to display
+	 */
+	Console(AbstractDisplay& display, RenderQueue& renderQueue) : display(display), renderQueue(renderQueue)
+	{
+	}
+
+	/**
+	 * @brief Use console for debug output
+	 * @param enable true to divert m_puts to console, false to disable debug output
+	 */
+	void systemDebugOutput(bool enable);
+
+	/**
+	 * @brief Suspend/resume output to display
+	 * @param state true to stop output, false to resume
+	 * 
+	 * While paused, content will be buffered in RAM.
+	 */
+	void pause(bool state);
+
+	/**
+	 * @brief Determine if output is paused
+	 */
+	bool isPaused() const
+	{
+		return paused;
+	}
+
+	/* Print methods */
+
+	size_t write(const uint8_t* data, size_t size) override;
+
+	size_t write(uint8_t c) override
+	{
+		return write(&c, 1);
+	}
+
+private:
+	void update();
+
+	AbstractDisplay& display;
+	RenderQueue& renderQueue;
+	String buffer;
+	String pauseBuffer;
+	std::unique_ptr<SceneObject> scene;
+	Point cursor{};
+	bool paused{false};
+};
+
+} // namespace Graphics

--- a/src/include/Graphics/Device.h
+++ b/src/include/Graphics/Device.h
@@ -60,6 +60,16 @@ public:
 		return orientation;
 	}
 
+	virtual bool setScrollMargins(uint16_t top, uint16_t bottom)
+	{
+		return false;
+	}
+
+	virtual bool scroll(int16_t y)
+	{
+		return false;
+	}
+
 protected:
 	Orientation orientation{};
 };

--- a/src/include/Graphics/Device.h
+++ b/src/include/Graphics/Device.h
@@ -60,15 +60,20 @@ public:
 		return orientation;
 	}
 
-	virtual bool setScrollMargins(uint16_t top, uint16_t bottom)
-	{
-		return false;
-	}
+	/**
+	 * @brief Set margins for hardware scrolling
+	 * @param top Number of fixed pixels at top of screen
+	 * @param bottom Number of fixed pixels at bottom of screen
+	 * 
+	 * Area between top/bottom can be scrolled using `scroll()` method.
+	 */
+	virtual bool setScrollMargins(uint16_t top, uint16_t bottom) = 0;
 
-	virtual bool scroll(int16_t y)
-	{
-		return false;
-	}
+	/**
+	 * @brief Scroll region of display up or down using hardware scrolling
+	 * @param y Number of lines to scroll. Positive values scroll content down, negative values scroll up.
+	 */
+	virtual bool scroll(int16_t y) = 0;
 
 protected:
 	Orientation orientation{};

--- a/src/include/Graphics/DisplayList.h
+++ b/src/include/Graphics/DisplayList.h
@@ -74,6 +74,16 @@ struct FillInfo {
 	}
 };
 
+__forceinline uint16_t swapBytes(uint16_t w)
+{
+	return (w >> 8) | (w << 8);
+}
+
+__forceinline uint32_t makeWord(uint16_t w1, uint16_t w2)
+{
+	return uint32_t(swapBytes(w1)) | (swapBytes(w2) << 16);
+}
+
 /**
  * @brief Stores list of low-level display commands
  *

--- a/src/include/Graphics/MipiDisplay.h
+++ b/src/include/Graphics/MipiDisplay.h
@@ -96,6 +96,14 @@ public:
 		return nativeSize;
 	}
 
+	Size getResolution() const
+	{
+		return resolution;
+	}
+
+	bool setScrollMargins(uint16_t top, uint16_t bottom) override;
+	bool scroll(int16_t y) override;
+
 	/* Device */
 
 	bool setOrientation(Orientation orientation) override;
@@ -119,6 +127,11 @@ public:
 	}
 
 	Surface* createSurface(size_t bufferSize = 0) override;
+
+	uint16_t getScrollOffset() const
+	{
+		return scrollOffset;
+	}
 
 protected:
 	/**
@@ -178,6 +191,7 @@ private:
 
 	uint8_t dcPin{PIN_NONE};
 	bool dcState{};
+	uint16_t scrollOffset{0};
 };
 
 class MipiSurface : public Graphics::Surface
@@ -215,7 +229,14 @@ public:
 
 	bool setAddrWindow(const Rect& rect) override
 	{
-		return displayList.setAddrWindow(rect + display.getAddrOffset());
+		Rect r = rect;
+		r.y -= display.getScrollOffset();
+		r += display.getAddrOffset();
+		while(r.y < 0) {
+			r.y += display.getResolution().h;
+		}
+		r.y %= display.getResolution().h;
+		return displayList.setAddrWindow(r);
 	}
 
 	uint8_t* getBuffer(uint16_t minBytes, uint16_t& available) override


### PR DESCRIPTION
This PR adds the `Graphics::Console` class to provide an easy way to print debug output to the screen.

To support this hardware scrolling is required, `setScrollMargins()` and `scroll()` methods added to `Graphics::Device`.

Both MIPI and Host implementations provided.
